### PR TITLE
Set the proper extends for the plugin metainfo

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.SonoBus.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.SonoBus.metainfo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
     <id>org.freedesktop.LinuxAudio.Plugins.SonoBus</id>
+    <extends>net.sonobus.SonoBus</extends>
     <name>SonoBus VST3</name>
     <summary>Free and open source network audio streaming, VST3 plugins</summary>
     <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
- this will make the VST3 plugin appear in GNOME software as an extension


(forgot this in the previous PR)