### PR TITLE
Update runtime to 22.08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules

--- a/net.sonobus.SonoBus.yaml
+++ b/net.sonobus.SonoBus.yaml
@@ -1,7 +1,7 @@
 app-id: net.sonobus.SonoBus
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '22.08'
 command: sonobus
 finish-args:
   - --share=ipc
@@ -18,18 +18,13 @@ finish-args:
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins.SonoBus:
     directory: extensions/Plugins/SonoBus
-    version: '21.08'
+    version: '22.08'
     add-ld-path": lib
     bundle: true
     subdirectories: true
     no-autodownload: true
     autodelete: false
-cleanup:
-  - /bin/alsa*
-  - /bin/jack*
 modules:
-  - shared-modules/linux-audio/jack2.json
-
   - name: SonoBus
     buildsystem: cmake-ninja
     post-install:
@@ -52,6 +47,8 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ([\d.]+)$
+      - type: patch
+        path: patches/juce-header.patch
       - type: file
         path: net.sonobus.SonoBus.metainfo.xml
       - type: file

--- a/org.freedesktop.LinuxAudio.Plugins.SonoBus.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.SonoBus.metainfo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
     <id>org.freedesktop.LinuxAudio.Plugins.SonoBus</id>
+    <extends>net.sonobus.SonoBus</extends>
     <name>SonoBus VST3</name>
     <summary>Free and open source network audio streaming, VST3 plugins</summary>
     <metadata_license>CC0-1.0</metadata_license>

--- a/patches/juce-header.patch
+++ b/patches/juce-header.patch
@@ -1,0 +1,11 @@
+--- SonoBus/deps/juce/modules/juce_gui_basics/native/juce_linux_Windowing.cpp-orig	2022-09-08 13:09:39.487640855 -0400
++++ SonoBus/deps/juce/modules/juce_gui_basics/native/juce_linux_Windowing.cpp	2022-09-08 13:09:55.546791063 -0400
+@@ -23,6 +23,8 @@
+   ==============================================================================
+ */
+ 
++#include <utility>
++
+ namespace juce
+ {
+ 


### PR DESCRIPTION
Remove jack2 (headers are in the runtime now) and shared-modules.